### PR TITLE
disabled door sprite renderer by default, narrowed exit collider

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 - Project name: tfs-jam-u25-team-hyzer
 - Unity version: Unity 6000.0.32f1
 - Active game object:
-  - Name: Player (1)
-  - Tag: Player
-  - Layer: Player
+  - Name: Checkpoint
+  - Tag: Untagged
+  - Layer: Default
 <!-- UNITY CODE ASSIST INSTRUCTIONS END -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 - Project name: tfs-jam-u25-team-hyzer
 - Unity version: Unity 6000.0.32f1
 - Active game object:
-  - Name: Checkpoint
+  - Name: Level Components
   - Tag: Untagged
   - Layer: Default
 <!-- UNITY CODE ASSIST INSTRUCTIONS END -->

--- a/Assets/Prefabs/Level Components/Level Components.prefab
+++ b/Assets/Prefabs/Level Components/Level Components.prefab
@@ -90,7 +90,7 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
-  m_Offset: {x: -0.7486801, y: 0.04159355}
+  m_Offset: {x: -1.1837158, y: 0.04159355}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -100,7 +100,7 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 2.4973602, y: 2.9687653}
+  m_Size: {x: 1.6272888, y: 2.9687653}
   m_EdgeRadius: 0
 --- !u!1 &670128827
 GameObject:
@@ -142,7 +142,7 @@ SpriteRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 670128827}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1

--- a/Assets/Prefabs/Level Components/Level Components.prefab
+++ b/Assets/Prefabs/Level Components/Level Components.prefab
@@ -27,8 +27,8 @@ Transform:
   m_GameObject: {fileID: 160162122}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 214.58751, y: 77.48019, z: 5.9794497}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: 296.54, y: 76.44, z: 5.9794497}
+  m_LocalScale: {x: -1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 670128829}
@@ -52,10 +52,10 @@ MonoBehaviour:
   anim: {fileID: 670128830}
   distanceToOpen: 7.5
   exitPoint: {fileID: 2075710851}
-  playerSpawnPoint: {fileID: 0}
-  playerStartPoint: {fileID: 0}
+  playerSpawnPoint: {fileID: 5856047972106533050}
+  playerStartPoint: {fileID: 3260202935811491726}
   movePlayerSpeed: 10
-  destinationLevel: test2
+  destinationLevel: area1
 --- !u!61 &160162126
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -318,7 +318,7 @@ Transform:
   m_GameObject: {fileID: 2075710850}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 3.97, y: 0, z: 0}
+  m_LocalPosition: {x: 1.01, y: -0.3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -349,7 +349,7 @@ Transform:
   m_GameObject: {fileID: 1599658687496753058}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -7.94, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -416,7 +416,7 @@ Transform:
   m_GameObject: {fileID: 4838505649542354805}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 82.480446, y: 73.05396, z: 6.056825}
+  m_LocalPosition: {x: 319.5, y: 74.9, z: 6.056825}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -456,7 +456,7 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
-  m_Offset: {x: 52.98114, y: 5.7879305}
+  m_Offset: {x: 32.86875, y: 7.992506}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -466,7 +466,7 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 160.09323, y: 22.338705}
+  m_Size: {x: 119.868454, y: 27.862919}
   m_EdgeRadius: 0
 --- !u!1 &4838505650467080932
 GameObject:
@@ -496,7 +496,7 @@ Transform:
   m_GameObject: {fileID: 4838505650467080932}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 80.567505, y: 77.99019, z: -4.0205503}
+  m_LocalPosition: {x: 354.5, y: 77.99019, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scenes/boss1.unity
+++ b/Assets/Scenes/boss1.unity
@@ -9192,11 +9192,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8865355478758606970, guid: 8a19208529d510e4a8cc3d377e46ec56, type: 3}
   m_PrefabInstance: {fileID: 1191048351}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &1192356470 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3260202935811491726, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-  m_PrefabInstance: {fileID: 2007224020}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1210983035
 GameObject:
   m_ObjectHideFlags: 0
@@ -11805,49 +11800,9 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 160162123, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-      propertyPath: m_LocalScale.x
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 160162123, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 296.54
-      objectReference: {fileID: 0}
-    - target: {fileID: 160162123, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 76.44
-      objectReference: {fileID: 0}
-    - target: {fileID: 160162125, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-      propertyPath: destinationLevel
-      value: area1
-      objectReference: {fileID: 0}
-    - target: {fileID: 160162125, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-      propertyPath: playerSpawnPoint
-      value: 
-      objectReference: {fileID: 2031393054}
-    - target: {fileID: 160162125, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-      propertyPath: playerStartPoint
-      value: 
-      objectReference: {fileID: 1192356470}
-    - target: {fileID: 2075710851, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 1.01
-      objectReference: {fileID: 0}
-    - target: {fileID: 2075710851, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 3260202935811491726, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -7.94
-      objectReference: {fileID: 0}
     - target: {fileID: 4838505649242643264, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
       propertyPath: m_Name
       value: Level Components
-      objectReference: {fileID: 0}
-    - target: {fileID: 4838505649242643265, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4838505649242643265, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -11889,48 +11844,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4838505649542354806, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 319.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4838505649542354806, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 74.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 4838505649542354807, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-      propertyPath: m_Size.x
-      value: 119.868454
-      objectReference: {fileID: 0}
-    - target: {fileID: 4838505649542354807, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-      propertyPath: m_Size.y
-      value: 27.862919
-      objectReference: {fileID: 0}
-    - target: {fileID: 4838505649542354807, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-      propertyPath: m_Offset.x
-      value: 32.86875
-      objectReference: {fileID: 0}
-    - target: {fileID: 4838505649542354807, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-      propertyPath: m_Offset.y
-      value: 7.992506
-      objectReference: {fileID: 0}
-    - target: {fileID: 4838505650467080728, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 354.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4838505650467080728, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -10
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
---- !u!4 &2031393054 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5856047972106533050, guid: e6bf85d961d723e46ab6afeec4a80cf2, type: 3}
-  m_PrefabInstance: {fileID: 2007224020}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &2042822829 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6342122171774143343, guid: b2f42edb8f198144b9c93b2bc81f6850, type: 3}

--- a/Assets/UniversalRenderPipelineGlobalSettings.asset
+++ b/Assets/UniversalRenderPipelineGlobalSettings.asset
@@ -33,27 +33,27 @@ MonoBehaviour:
   m_Settings:
     m_SettingsList:
       m_List:
-      - rid: 3346108135068664275
+      - rid: 3346108135068664313
       - rid: 627024031368872251
       - rid: 627024031368872252
       - rid: 627024031368872253
-      - rid: 3346108135068664276
+      - rid: 3346108135068664314
       - rid: 627024031368872255
       - rid: 627024031368872256
-      - rid: 3346108135068664277
+      - rid: 3346108135068664315
       - rid: 627024031368872258
       - rid: 627024031368872259
-      - rid: 3346108135068664278
-      - rid: 3346108135068664279
+      - rid: 3346108135068664316
+      - rid: 3346108135068664317
       - rid: 627024031368872262
-      - rid: 3346108135068664280
-      - rid: 3346108135068664281
-      - rid: 3346108135068664282
+      - rid: 3346108135068664318
+      - rid: 3346108135068664319
+      - rid: 3346108135068664320
       - rid: 627024031368872266
-      - rid: 3346108135068664283
-      - rid: 3346108135068664284
+      - rid: 3346108135068664321
+      - rid: 3346108135068664322
       - rid: 627024031368872269
-      - rid: 3346108135068664285
+      - rid: 3346108135068664323
     m_RuntimeSettings:
       m_List:
       - rid: 627024031368872251
@@ -160,7 +160,7 @@ MonoBehaviour:
         m_ExportShaderVariants: 1
         m_ShaderVariantLogLevel: 0
         m_StripRuntimeDebugShaders: 1
-    - rid: 3346108135068664275
+    - rid: 3346108135068664313
       type: {class: UniversalRenderPipelineEditorShaders, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_AutodeskInteractive: {fileID: 4800000, guid: 0e9d5a909a1f7e84882a534d0d11e49f, type: 3}
@@ -172,7 +172,7 @@ MonoBehaviour:
         m_DefaultSpeedTree7Shader: {fileID: 4800000, guid: 0f4122b9a743b744abe2fb6a0a88868b, type: 3}
         m_DefaultSpeedTree8Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
         m_DefaultSpeedTree9Shader: {fileID: -6465566751694194690, guid: cbd3e1cc4ae141c42a30e33b4d666a61, type: 3}
-    - rid: 3346108135068664276
+    - rid: 3346108135068664314
       type: {class: UniversalRenderPipelineEditorMaterials, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_DefaultMaterial: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
@@ -181,14 +181,14 @@ MonoBehaviour:
         m_DefaultTerrainMaterial: {fileID: 2100000, guid: 594ea882c5a793440b60ff72d896021e, type: 2}
         m_DefaultDecalMaterial: {fileID: 2100000, guid: 31d0dcc6f2dd4e4408d18036a2c93862, type: 2}
         m_DefaultSpriteMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
-    - rid: 3346108135068664277
+    - rid: 3346108135068664315
       type: {class: URPShaderStrippingSetting, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
         m_StripUnusedPostProcessingVariants: 0
         m_StripUnusedVariants: 1
         m_StripScreenCoordOverrideVariants: 1
-    - rid: 3346108135068664278
+    - rid: 3346108135068664316
       type: {class: UniversalRendererResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
@@ -196,7 +196,7 @@ MonoBehaviour:
         m_CameraMotionVector: {fileID: 4800000, guid: c56b7e0d4c7cb484e959caeeedae9bbf, type: 3}
         m_StencilDeferredPS: {fileID: 4800000, guid: e9155b26e1bc55942a41e518703fe304, type: 3}
         m_DBufferClear: {fileID: 4800000, guid: f056d8bd2a1c7e44e9729144b4c70395, type: 3}
-    - rid: 3346108135068664279
+    - rid: 3346108135068664317
       type: {class: GPUResidentDrawerResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.GPUDriven.Runtime}
       data:
         m_Version: 0
@@ -209,21 +209,21 @@ MonoBehaviour:
         m_OcclusionCullingDebugKernels: {fileID: 7200000, guid: b23e766bcf50ca4438ef186b174557df, type: 3}
         m_DebugOcclusionTestPS: {fileID: 4800000, guid: d3f0849180c2d0944bc71060693df100, type: 3}
         m_DebugOccluderPS: {fileID: 4800000, guid: b3c92426a88625841ab15ca6a7917248, type: 3}
-    - rid: 3346108135068664280
+    - rid: 3346108135068664318
       type: {class: ProbeVolumeRuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
         probeVolumeBlendStatesCS: {fileID: 7200000, guid: a3f7b8c99de28a94684cb1daebeccf5d, type: 3}
         probeVolumeUploadDataCS: {fileID: 7200000, guid: 0951de5992461754fa73650732c4954c, type: 3}
         probeVolumeUploadDataL2CS: {fileID: 7200000, guid: 6196f34ed825db14b81fb3eb0ea8d931, type: 3}
-    - rid: 3346108135068664281
+    - rid: 3346108135068664319
       type: {class: IncludeAdditionalRPAssets, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_version: 0
         m_IncludeReferencedInScenes: 0
         m_IncludeAssetsByLabel: 0
         m_LabelToInclude: 
-    - rid: 3346108135068664282
+    - rid: 3346108135068664320
       type: {class: ProbeVolumeBakingResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -236,7 +236,7 @@ MonoBehaviour:
         skyOcclusionRT: {fileID: -5126288278712620388, guid: 5a2a534753fbdb44e96c3c78b5a6999d, type: 3}
         renderingLayerCS: {fileID: -6772857160820960102, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
         renderingLayerRT: {fileID: -5126288278712620388, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
-    - rid: 3346108135068664283
+    - rid: 3346108135068664321
       type: {class: ProbeVolumeDebugResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -246,12 +246,12 @@ MonoBehaviour:
         probeVolumeOffsetDebugShader: {fileID: 4800000, guid: db8bd7436dc2c5f4c92655307d198381, type: 3}
         probeSamplingDebugMesh: {fileID: -3555484719484374845, guid: 20be25aac4e22ee49a7db76fb3df6de2, type: 3}
         numbersDisplayTex: {fileID: 2800000, guid: 73fe53b428c5b3440b7e87ee830b608a, type: 3}
-    - rid: 3346108135068664284
+    - rid: 3346108135068664322
       type: {class: ProbeVolumeGlobalSettings, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
         m_ProbeVolumeDisableStreamingAssets: 0
-    - rid: 3346108135068664285
+    - rid: 3346108135068664323
       type: {class: STP/RuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_setupCS: {fileID: 7200000, guid: 33be2e9a5506b2843bdb2bdff9cad5e1, type: 3}


### PR DESCRIPTION
would add separate door prefabs but our seed tutorial for this project nested them in level components, don't have time to do this properly before the jam deadline